### PR TITLE
mount.cifs: fix buffer overrun in set_password

### DIFF
--- a/mount.cifs.c
+++ b/mount.cifs.c
@@ -350,13 +350,13 @@ set_password(struct parsed_mount_info *parsed_info, const char *src,
 	unsigned int i = 0, j = 0;
 
 	while (src[i]) {
-		if (src[i] == ',')
-			dst[j++] = ',';
-		dst[j++] = src[i++];
-		if (j > pass_length) {
+		if (j + 2 >= pass_length) {
 			fprintf(stderr, "Converted password too long!\n");
 			return EX_USAGE;
 		}
+		if (src[i] == ',')
+			dst[j++] = ',';
+		dst[j++] = src[i++];
 	}
 	dst[j] = '\0';
 	if (is_pass2)


### PR DESCRIPTION
The existing (j > pass_length) check is insufficient to avoid dst buffer overrun into the start of the adjacent struct parsed_mount_info field. Check for overrun before writing to dst, and account for comma-expansion and null-termination.

Bug: https://bugzilla.samba.org/show_bug.cgi?id=16044

Reported-by: Bruno Bierbaumer <bruno@bierbaumer.net>