### PR TITLE
cifs.upcall: fix compiler warning with -Wvla

### DIFF
--- a/cifs.upcall.c
+++ b/cifs.upcall.c
@@ -1376,7 +1376,7 @@ static int ip_to_fqdn(const char *addrstr, char *host, size_t hostlen)
 }
 
 /* cover worst case/impossible scenarios, + 1 for NUL */
-#define PROC_PID_PATH_MAXLEN	((int)strlen("/proc/2147483647/status") + 1)
+#define PROC_PID_PATH_MAXLEN	((int)sizeof("/proc/2147483647/status"))
 /* max valid UID/GID is (UINT_MAX - 1) */
 #define INVALID_UIDGID		UINT_MAX
 


### PR DESCRIPTION
The length value for @path array in get_uidgid() needs to be evaluated at compile time, so replace strlen() with sizeof() when defining PROC_PID_PATH_MAXLEN and then fix the following warning:

 cifs.upcall.c: In function ‘get_uidgid’:
 cifs.upcall.c:1400:9: warning: ISO C90 forbids array ‘path’ whose size
 cannot be evaluated [-Wvla]
  1400 |         char path[PROC_PID_PATH_MAXLEN] = {}, buf[256];
       |         ^~~~

Fixes: 972c5b5ff95e ("cifs.upcall: remove getpwuid() dependency")

Cc: Enzo Matsumiya <ematsumiya@suse.de>
Cc: linux-cifs@vger.kernel.org