### PR TITLE
mount.cifs: fix const correctness in parse_options

### DIFF
--- a/mount.cifs.c
+++ b/mount.cifs.c
@@ -834,7 +834,7 @@ static int parse_opt_token(const char *token)
 }
 
 static int
-parse_options(const char *data, struct parsed_mount_info *parsed_info)
+parse_options(char *data, struct parsed_mount_info *parsed_info)
 {
 	char *value = NULL;
 	char *equals = NULL;


### PR DESCRIPTION
parse_options() modifies the string it receives in-place, temporarily null-terminating keyword and value boundaries. The const qualifier on the data parameter was wrong; remove it so the compiler can verify the pointer assignments are valid.