### PR TITLE
cifs.upcall: fix regression with krb5 + creduid

### DIFF
--- a/cifs.upcall.c
+++ b/cifs.upcall.c
@@ -1708,15 +1708,27 @@ int main(const int argc, char *const argv[])
 	if (uid == 0)
 		env_probe = false;
 
-	/*
-	 * FIXME: this only works if we haven't switched PID namespaces.
-	 * If we did, /proc/arg->pid/ might not exist, or worse, point to something else.
-	 */
-	rc = get_uidgid(arg->pid, &uid, &gid);
-	if (rc) {
-		syslog(LOG_ERR, "get_uidgid (NS): %s", strerror(errno));
-		rc = 1;
-		goto out;
+	gid = INVALID_UIDGID;
+	if (arg->uid == 0) {
+		/*
+		 * By now, 'uid' is either 0 or 'arg->creduid'.
+		 * In either case, we just need to set GID=0 to make setgid() happy, as kerberos
+		 * credential cache lookup relies only on UID anyway (in case arg->creduid != 0).
+		 */
+		gid = 0;
+	} else {
+		/*
+		 * For any other case, we need to get UID/GID from procfs.
+		 *
+		 * FIXME: this only works if we haven't switched PID namespaces.
+		 * If we did, /proc/arg->pid/ might not exist, or worse, point to something else.
+		 */
+		rc = get_uidgid(arg->pid, &uid, &gid);
+		if (rc) {
+			syslog(LOG_ERR, "get_uidgid (NS): %s", strerror(errno));
+			rc = 1;
+			goto out;
+		}
 	}
 
 	rc = setgid(gid);


### PR DESCRIPTION
With 'mount.cifs -o sec=krb5,cruid=XXX' (where XXX > 0), get_uidgid() maps XXX to 0, as mount.cifs is running as root.

This makes kerberos lookup for credentials for UID 0, which, if not existent, will fail with -ENOKEY.

To fix this, simply ignore UID/GID mapping (get_uidgid() call) when arg->uid == 0, as cifs.upcall is already running as root anyway, and then kerberos will use 'uid' (which might be 0 or cruid) for lookup.

Fixes: 972c5b5ff95e ("cifs.upcall: remove getpwuid() dependency")
Reported-by: Paulo Alcantara <pc@manguebit.org>
Reviewed-by: Paulo Alcantara (Red Hat) <pc@manguebit.org>