### PR TITLE
cifs.upcall: Avoid int overflow after year 2038

### DIFF
--- a/cifs.upcall.c
+++ b/cifs.upcall.c
@@ -247,7 +247,7 @@ static time_t get_tgt_time(krb5_ccache ccache)
 		    !strncasecmp(name + KRB5_TGS_NAME_SIZE + 1, realm,
 				 strlen(realm))
 		    && creds.times.endtime > time(NULL))
-			credtime = creds.times.endtime;
+			credtime = (unsigned)creds.times.endtime;
 		krb5_free_cred_contents(context, &creds);
 		krb5_free_unparsed_name(context, name);
 	}


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/Year_2038_problem

This patch was done while reviewing potential year-2038 issues in openSUSE.

https://web.mit.edu/kerberos/krb5-devel/doc/appdev/refs/types/krb5_timestamp.html

Reviewed-by: Henrique Carvalho <henrique.carvalho@suse.com>